### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 
 node_js:
   - "12"
-  - "13"
+  - "14"
+  - "16"
   - "node"
 
 install:
@@ -13,3 +14,4 @@ env:
   - HAPI_VERSION="17"
   - HAPI_VERSION="18"
   - HAPI_VERSION="19"
+  - HAPI_VERSION="20"

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Zlib = require('zlib');
 
 const Hoek = require('@hapi/hoek');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 
 const internals = {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "@hapi/joi": "^17.1.1"
+    "joi": "^17.1.1"
   },
   "devDependencies": {
     "@hapi/code": "^8.0.1",
-    "@hapi/hapi": "^19.1.1",
-    "@hapi/lab": "^22.0.4"
+    "@hapi/hapi": "^20.1.3",
+    "@hapi/lab": "^24.2.1"
   },
   "scripts": {
     "test": "lab -f -a @hapi/code -t 100 -L",


### PR DESCRIPTION
This removes a warning on install because joi was renamed (out from under the hapi umbrella).